### PR TITLE
Improve font size in mobile view code blocks

### DIFF
--- a/src/styles/global.sass
+++ b/src/styles/global.sass
@@ -83,6 +83,10 @@ a:hover
 code, code[class*="language-"]
   color: colors.$light
   font-family: fonts.$family-mono
+  font-size: fonts.$size-regular
+@media all and (max-width: #{ layout.$screen-small })
+  code, code[class*="language-"]
+    font-size: fonts.$size-small
 code > .token.boolean, .token.number, .token.function
   color: colors.$action
 code > .token.operator, .token.entity, .token.url


### PR DESCRIPTION
Fonts were too big on small screens in code blocks. Adding a
media query on they global style sheet fixes this.