### PR TITLE
Update to use description where available

### DIFF
--- a/src/components/blog/PostSummary.spec.tsx
+++ b/src/components/blog/PostSummary.spec.tsx
@@ -21,6 +21,13 @@ export namespace Factories {
         tags: ['tag1', 'tag2'],
       }
     }
+
+    static createWithDescription(): ComponentPost {
+      return {
+        ...Factories.Post.create(),
+        description: 'a description',
+      }
+    }
   }
 }
 
@@ -41,6 +48,14 @@ describe('component/PostSummary', () => {
 
   it('renders an excerpt', () => {
     expect(postSummary.find('p').text()).to.equal('excerpt')
+  })
+
+  it('renders the description instead of an excerpt, if provided', () => {
+    expect(
+      shallow(<PostSummary post={Factories.Post.createWithDescription()} />)
+        .find('p')
+        .text()
+    ).to.equal('a description')
   })
 
   it("renders a post's tags", () => {

--- a/src/components/blog/PostSummary.tsx
+++ b/src/components/blog/PostSummary.tsx
@@ -9,6 +9,7 @@ export interface Post {
   date: string
   slug: string
   excerpt: string
+  description?: string
   tags: string[] | null
 }
 
@@ -41,7 +42,9 @@ export const PostSummary = ({ post }: Props) => (
           </ul>
         ) : null}
       </div>
-      <p className={styles.regularColor}>{post.excerpt}</p>
+      <p className={styles.regularColor}>
+        {post.description ? post.description : post.excerpt}
+      </p>
     </div>
   </Link>
 )

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -12,7 +12,7 @@ interface Props {
 const Blog = ({ data }: Props) => {
   const posts = data.posts.edges.map(
     ({ node }: any): Post => {
-      return {
+      const post: Post = {
         id: node.id,
         title: node.frontmatter.title,
         date: node.frontmatter.date,
@@ -20,6 +20,12 @@ const Blog = ({ data }: Props) => {
         excerpt: node.excerpt,
         tags: node.frontmatter.tags,
       }
+
+      if (node.frontmatter.description) {
+        post['description'] = node.frontmatter.description
+      }
+
+      return post
     }
   )
 
@@ -46,6 +52,7 @@ export const query = graphql`
             title
             date(formatString: "DD MMMM, YYYY")
             tags
+            description
           }
           fields {
             slug


### PR DESCRIPTION
Some posts have a description (or kind of a TL;DR) in frontmatter, this
gets used instead of the excerpt in the post list now.

closes #76 